### PR TITLE
Add appsettings.Development.json with Linux connection string

### DIFF
--- a/ToDoList-backend/ToDoList.Api/appsettings.Development-Linux.json
+++ b/ToDoList-backend/ToDoList.Api/appsettings.Development-Linux.json
@@ -1,0 +1,23 @@
+{
+  "AllowedOrigins": "http://localhost:4200/",
+  "AppSettings": {
+    "Secret": "This is a secret authentication phase which should be always unique for the application"
+  },
+  "ConnectionStrings": {
+    "ToDoListDatabase": "Server=.;Database=ToDoList;User Id=sa;Password=TypeYourSAPasswordHere;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "SmtpSettings": {
+    "Host": "smtp.gmail.com",
+    "Port": 587,
+    "EnableSsl": true,
+    "Username": "{provide_gmail_username}",
+    "Password": "{provide_gmail_password}"
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Added appsettings.Development-Linux.json

Instruction for Linux users(like Mint 22 Zara):
Copy connection string from appsettings.Development-Linux.json to appsettings.Development.json and put your SQL Server SA user password there.

Don't commit your password to repo! Leave it locally.